### PR TITLE
fix(CI): remove CI flag to dissmis `MiniCssExtractPlugin`

### DIFF
--- a/.github/workflows/deploy-develop.yml
+++ b/.github/workflows/deploy-develop.yml
@@ -26,6 +26,7 @@ jobs:
 
       - name: Build site
         env:
+          CI: false
           PUBLIC_URL: ${{ secrets.PUBLIC_URL }}
           REACT_APP_BASENAME: ${{ secrets.REACT_APP_BASENAME }}
           REACT_APP_CRYPTO_COMPARE_API_KEY: ${{ secrets.REACT_APP_CRYPTO_COMPARE_API_KEY }}

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -1,15 +1,16 @@
 name: Deploy Develop
 
 on:
-  push:
-    branches:
-      - develop
+  pull_request:
+    types:
+      - opened
+      - edited
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
     environment: development
-    name: Deploy
+    name: Test PR
     steps:
       - uses: actions/checkout@v2
 
@@ -39,9 +40,3 @@ jobs:
           REACT_APP_MOONPAY_API_KEY: ${{ secrets.REACT_APP_MOONPAY_API_KEY }}
           REACT_APP_MOONPAY_SIGNER_URL: ${{ secrets.REACT_APP_MOONPAY_SIGNER_URL }}
         run: yarn build
-
-      - name: Publish
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./packages/web/build

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -1,4 +1,4 @@
-name: Deploy Develop
+name: Test PR
 
 on:
   pull_request:
@@ -7,7 +7,7 @@ on:
       - edited
 
 jobs:
-  deploy:
+  test:
     runs-on: ubuntu-latest
     environment: development
     name: Test PR


### PR DESCRIPTION
The problem is with `MiniCssExtractPlugin`, which is not customizable with the current `CRA` setup.
Adding an extra github workflow to test CI builds before merging PRs.

The `MiniCssExtractPlugin`'s problem will be addressed in [webpack setup](https://p2pvalidator.atlassian.net/browse/PWN-3411)